### PR TITLE
[Circuit monad] Proper soundness using env function

### DIFF
--- a/Clean/Circuit/Circuit.lean
+++ b/Clean/Circuit/Circuit.lean
@@ -416,15 +416,13 @@ where
   spec: β.value → α.value → Prop
 
   soundness:
-    -- for all inputs that satisfy the assumptions
-    ∀ b : β.value, assumptions b →
-    -- for all locally witnessed values
+    -- for all environments that determine witness generation
     ∀ env: ℕ → F,
-    -- assuming input variables that evaluate to the inputs
-    ∀ b_var : β.var, Provable.eval_env env b_var = b →
+    -- for all inputs that satisfy the assumptions
+    ∀ b : β.value, ∀ b_var : β.var, Provable.eval_env env b_var = b → assumptions b →
     -- if the constraints hold
     Adversarial.constraints_hold env (main b_var) →
-    -- the the spec holds on the output
+    -- the spec holds on the input and output
     let a := Provable.eval_env env (output (main b_var))
     spec b a
 
@@ -455,7 +453,7 @@ def formal_circuit_to_subcircuit
     (a_var: α.var) ×
     SubCircuit F
     (subcircuit_soundness circuit b_var a_var) (subcircuit_completeness circuit b_var) :=
-  let main := circuit.main b_var -- TODO
+  let main := circuit.main b_var
 
   -- modify `main` so that we optionally force the output variable to have a fixed value
   let main' := do
@@ -689,7 +687,7 @@ def circuit : FormalCircuit (F p) (fields (F p) 3) (field (F p)) where
   spec := spec
   soundness := by
     -- introductions
-    rintro ⟨ inputs, _ ⟩ as env ⟨ inputs_var, _ ⟩ h_inputs
+    rintro env ⟨ inputs, _ ⟩ ⟨ inputs_var, _ ⟩ h_inputs as
     let [x, y, carry_in] := inputs
     let [x_var, y_var, carry_in_var] := inputs_var
     -- let [z, carry_out] := witnesses
@@ -790,7 +788,7 @@ def circuit : FormalCircuit (F p) (fields (F p) 2) (field (F p)) where
   spec := spec
   soundness := by
     -- introductions
-    rintro ⟨ inputs, _ ⟩ as env ⟨ inputs_var, _ ⟩ h_inputs
+    rintro env ⟨ inputs, _ ⟩ ⟨ inputs_var, _ ⟩ h_inputs as
     let [x, y] := inputs
     let [x_var, y_var] := inputs_var
     intro h_holds z

--- a/Clean/Circuit/Circuit.lean
+++ b/Clean/Circuit/Circuit.lean
@@ -243,7 +243,7 @@ namespace Adversarial
       | Operation.Circuit { soundness, .. } => soundness env ∧ constraints_hold_from_list env ops
       | _ => constraints_hold_from_list env ops
 
-  @[reducible]
+  @[reducible, simp]
   def constraints_hold [Field F] (env: (ℕ → F)) (circuit: Stateful F α) : Prop :=
     constraints_hold_from_list env circuit.operations
 end Adversarial
@@ -626,8 +626,7 @@ def circuit : FormalCircuit (F p) (fields (F p) 3) (field (F p)) where
     guard_hyp hy : y_var.eval_env env = y
     guard_hyp hcarry_in : carry_in_var.eval_env env = carry_in
 
-    -- we use a trick to get Lean to display the actual parts of `h_holds` for us!
-    have h_holds: _ ∧ _ ∧ _  := h_holds
+    -- simplify constraints hypothesis
     dsimp at h_holds
     let z := env 0
     let carry_out := env 1
@@ -723,9 +722,7 @@ def circuit : FormalCircuit (F p) (fields (F p) 2) (field (F p)) where
     dsimp at hx hy
 
     -- simplify constraints hypothesis
-    -- we know it must be just the `subcircuit_soundness` of `Add8Full.circuit`
-    -- so it has an implication form
-    have h_holds : _ → _ := h_holds
+    -- it's just the `subcircuit_soundness` of `Add8Full.circuit`
     dsimp at h_holds
 
     -- rewrite input and ouput values

--- a/Clean/Circuit/Circuit.lean
+++ b/Clean/Circuit/Circuit.lean
@@ -614,7 +614,6 @@ def circuit : FormalCircuit (F p) (fields (F p) 3) (field (F p)) where
     rintro env ⟨ inputs, _ ⟩ ⟨ inputs_var, _ ⟩ h_inputs as
     let [x, y, carry_in] := inputs
     let [x_var, y_var, carry_in_var] := inputs_var
-    -- let [z, carry_out] := witnesses
     rintro h_holds z'
 
     -- characterize inputs

--- a/Clean/Circuit/Provable.lean
+++ b/Clean/Circuit/Provable.lean
@@ -57,6 +57,7 @@ def const (F: Type) [ProvableType F α] (x: α.value) : α.var :=
 @[reducible]
 def field (F : Type) : TypePair := ⟨ Expression F, F ⟩
 
+@[simp]
 instance : ProvableType F (field F) where
   size := 1
   to_vars x := vec [x]
@@ -70,6 +71,7 @@ def pair (α β : TypePair) : TypePair := ⟨ α.var × β.var, α.value × β.v
 @[reducible]
 def field2 (F : Type) : TypePair := pair (field F) (field F)
 
+@[simp]
 instance : ProvableType F (field2 F) where
   size := 2
   to_vars pair := vec [pair.1, pair.2]
@@ -83,6 +85,7 @@ def vec (α: TypePair) (n: ℕ) : TypePair := ⟨ Vector α.var n, Vector α.val
 @[reducible]
 def fields (F: Type) (n: ℕ) : TypePair := vec (field F) n
 
+@[simp]
 instance : ProvableType F (fields F n) where
   size := n
   to_vars x := x

--- a/Clean/Utils/Vector.lean
+++ b/Clean/Utils/Vector.lean
@@ -22,6 +22,7 @@ namespace Vector
     | ⟨ [], ha ⟩, ⟨ [], _ ⟩  => ⟨ [], ha ⟩
     | ⟨ a::as, ha ⟩, ⟨ b::bs, hb ⟩ => ⟨ (a, b) :: List.zip as bs, by sorry ⟩
 
+  @[simp]
   def get (v: Vector α n) (i: Fin n) : α :=
     let i' : Fin v.1.length := Fin.cast (length_matches v).symm i
     v.val.get i'


### PR DESCRIPTION
* remove the possibility of passing in witness value inputs when running a circuit, and instead use the more general and sound notion that the prover can use any `env: Nat -> F` to determine assignment of values to variables
* modify `SubCircuit` structure to a form which I think will stand the test of time
* prove a larger part of the underlying justification for replacing subcircuits with their specs
  * reduce the theorem that allows us to use a `FormalCircuit` as a `SubCircuit` to the equivalence of flattened and nested constraints
* remove lots of (now) obsolete code